### PR TITLE
Changed the NTP server and added the option to patch gps_debug.conf. Added SUPL_PORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2024-16-11
+
+🎉 Patch gps_debug.conf if present and switched to global ntp server
+
+### Changed
+
+- Use `7275` as `SUPL_PORT`, as some devices wont have it set as the default.
+- Use `pool.ntp.org` as `NTP_SERVER` ([see](https://github.com/Magisk-Modules-Alt-Repo/supl-replacer/issues/2))
+
+### Fixed
+
+- Fix gps_debug.conf not being patched if present, causing the module to not work on some devices ([see](https://github.com/Magisk-Modules-Alt-Repo/supl-replacer/issues/3#issuecomment-1892796390))
+
 ## [2.2.1] - 2023-03-13
 
 🎉 Support updating module via Magisk Manager
@@ -49,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - A license file
 - GitHub workflows to lint the script as well as build and publish the module
 
+[2.2.1]: https://github.com/Magisk-Modules-Alt-Repo/supl-replacer/releases/tag/v2.2.2
 [2.2.1]: https://github.com/Magisk-Modules-Alt-Repo/supl-replacer/releases/tag/v2.2.1
 [2.2.0]: https://github.com/D3SOX/magisk-supl-replacer/releases/tag/v2.2.0
 [2.1.0]: https://github.com/D3SOX/magisk-supl-replacer/releases/tag/v2.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Magisk SUPL replacer
 
-Magisk module to replace the SUPL (Secure User-Plane Location) provider in Android's gps.conf.
+Magisk module to replace the SUPL (Secure User-Plane Location) provider in Android's gps.conf (or gps_debug.conf).
 
 ## Background
 
@@ -23,7 +23,7 @@ If you want to learn more about the subject here's some reading material:
 - A blog post by a German security researcher that has done an in-depth analysis on to replace the SUPL provider: <https://www.kuketz-blog.de/android-imsi-leaking-bei-gps-positionsbestimmung/>
 - A post on the subreddit /r/degoogle describing other modification you can make to android in order to "degoogle it" more: <https://www.reddit.com/r/degoogle/comments/cldohl/how_to_degoogle_lineageos_in_2019/>
 
-This module also replaces the NTP server specified in the same configuration file with `europe.pool.ntp.org` which when resolved returns the IP of the closest european NTP server.
+This module also replaces the NTP server specified in the same configuration file with `pool.ntp.org` which when resolved returns the IP of the closest NTP server.
 
 ## Installation
 

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=supl-replacer
 name=A-GPS SUPL replacer
-version=v2.2.1
-versionCode=5
+version=v2.2.2
+versionCode=6
 author=PlqnK, D3SOX
-description=Replace the SUPL (Secure User-Plane Location) provider in Android's gps.conf.
+description=Replace the SUPL (Secure User-Plane Location) provider in Android's gps.conf (or gps_debug.conf).
 updateJson=https://raw.githubusercontent.com/Magisk-Modules-Alt-Repo/supl-replacer/master/update.json

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -2,8 +2,13 @@
 
 MODDIR=${0%/*}
 
-SUPL_HOST=supl.grapheneos.org
-NTP_SERVER=europe.pool.ntp.org
+# Switch to the non-tracking graphene os supl provider
+SUPL_HOST=supl.grapheneos.orgf
+# Ensure the supl port as some devices wont set it by default
+SUPL_PORT=7275
+# Use the global pool.ntp.org to get the closest ntp server available
+# See https://www.ntppool.org/zone/@
+NTP_SERVER=pool.ntp.org
 
 # For new "Treble enabled" devices
 if [ -f /system/vendor/etc/gps.conf ]; then
@@ -12,9 +17,11 @@ if [ -f /system/vendor/etc/gps.conf ]; then
   if grep -q "^SUPL_HOST=.*" "${MODDIR}/system/vendor/etc/gps.conf"; then
     # replace if it's already there
     sed -i "s/^SUPL_HOST=.*/SUPL_HOST=${SUPL_HOST}/" "${MODDIR}/system/vendor/etc/gps.conf"
+    sed -i "s/^SUPL_PORT=.*/SUPL_PORT=${SUPL_PORT}/" "${MODDIR}/system/vendor/etc/gps.conf"
   else
     # append if it's not there yet
     echo "SUPL_HOST=${SUPL_HOST}" >> "${MODDIR}/system/vendor/etc/gps.conf"
+    echo "SUPL_PORT=${SUPL_PORT}" >> "${MODDIR}/system/vendor/etc/gps.conf"
   fi
 
   sed -i "s/^NTP_SERVER=.*/NTP_SERVER=${NTP_SERVER}/" "${MODDIR}/system/vendor/etc/gps.conf"
@@ -35,12 +42,34 @@ if [ -f /system/etc/gps.conf ]; then
   if grep -q "^SUPL_HOST=.*" "${MODDIR}/system/etc/gps.conf"; then
     # replace if it's already there
     sed -i "s/^SUPL_HOST=.*/SUPL_HOST=${SUPL_HOST}/" "${MODDIR}/system/etc/gps.conf"
+    sed -i "s/^SUPL_PORT=.*/SUPL_PORT=${SUPL_PORT}/" "${MODDIR}/system/etc/gps.conf"
   else
     # append if it's not there yet
     echo "SUPL_HOST=${SUPL_HOST}" >> "${MODDIR}/system/etc/gps.conf"
+    echo "SUPL_HOST=${SUPL_PORT}" >> "${MODDIR}/system/etc/gps.conf"
   fi
 
   sed -i "s/^NTP_SERVER=.*/NTP_SERVER=${NTP_SERVER}/" "${MODDIR}/system/etc/gps.conf"
+fi
+
+# For devices where only gps_debug is present
+if [ -f /system/etc/gps_debug.conf ] && [ ! -f /system/etc/gps.confg ]; then
+  cp /system/etc/gps_debug.conf "${MODDIR}/system/etc/gps_debug.conf"
+
+  if grep -q "^SUPL_HOST=.*" "${MODDIR}/system/etc/gps_debug.conf"; then
+    # replace if it's already there
+    sed -i "s/^SUPL_HOST=.*/SUPL_HOST=${SUPL_HOST}/" "${MODDIR}/system/etc/gps_debug.conf"
+    sed -i "s/^SUPL_PORT=.*/SUPL_HOST=${SUPL_PORT}/" "${MODDIR}/system/etc/gps_debug.conf"
+  else
+    # append if it's not there yet
+    echo "SUPL_HOST=${SUPL_HOST}" >> "${MODDIR}/system/etc/gps_debug.conf"
+    echo "SUPL_HOST=${SUPL_PORT}" >> "${MODDIR}/system/etc/gps_debug.conf"
+  fi
+
+  sed -i "s/^NTP_SERVER=.*/NTP_SERVER=${NTP_SERVER}/" "${MODDIR}/system/etc/gps_debug.conf"
+
+# Moved cleanup to avoid code duplication
+if [ -f /system/etc/gps.conf ] || [ -f /system/etc/gps_debug.conf ]; then
   if [ -f "${MODDIR}/system/etc/.gitkeep" ]; then
     rm "${MODDIR}/system/etc/.gitkeep"
   fi

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -3,7 +3,7 @@
 MODDIR=${0%/*}
 
 # Switch to the non-tracking graphene os supl provider
-SUPL_HOST=supl.grapheneos.orgf
+SUPL_HOST=supl.grapheneos.org
 # Ensure the supl port as some devices wont set it by default
 SUPL_PORT=7275
 # Use the global pool.ntp.org to get the closest ntp server available
@@ -46,14 +46,14 @@ if [ -f /system/etc/gps.conf ]; then
   else
     # append if it's not there yet
     echo "SUPL_HOST=${SUPL_HOST}" >> "${MODDIR}/system/etc/gps.conf"
-    echo "SUPL_HOST=${SUPL_PORT}" >> "${MODDIR}/system/etc/gps.conf"
+    echo "SUPL_PORT=${SUPL_PORT}" >> "${MODDIR}/system/etc/gps.conf"
   fi
 
   sed -i "s/^NTP_SERVER=.*/NTP_SERVER=${NTP_SERVER}/" "${MODDIR}/system/etc/gps.conf"
 fi
 
 # For devices where only gps_debug is present
-if [ -f /system/etc/gps_debug.conf ] && [ ! -f /system/etc/gps.confg ]; then
+if [ -f /system/etc/gps_debug.conf ] && [ ! -f /system/etc/gps.conf ]; then
   cp /system/etc/gps_debug.conf "${MODDIR}/system/etc/gps_debug.conf"
 
   if grep -q "^SUPL_HOST=.*" "${MODDIR}/system/etc/gps_debug.conf"; then
@@ -67,6 +67,7 @@ if [ -f /system/etc/gps_debug.conf ] && [ ! -f /system/etc/gps.confg ]; then
   fi
 
   sed -i "s/^NTP_SERVER=.*/NTP_SERVER=${NTP_SERVER}/" "${MODDIR}/system/etc/gps_debug.conf"
+fi
 
 # Moved cleanup to avoid code duplication
 if [ -f /system/etc/gps.conf ] || [ -f /system/etc/gps_debug.conf ]; then

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-    "version": "v2.2.1",
-    "versionCode": 5,
-    "zipUrl": "https://github.com/Magisk-Modules-Alt-Repo/supl-replacer/releases/download/v2.2.1/supl-replacer-v2.2.1.zip",
+    "version": "v2.2.2",
+    "versionCode": 6,
+    "zipUrl": "https://github.com/Magisk-Modules-Alt-Repo/supl-replacer/releases/download/v2.2.2/supl-replacer-v2.2.2.zip",
     "changelog": "https://raw.githubusercontent.com/Magisk-Modules-Alt-Repo/supl-replacer/master/CHANGELOG.md"
 }


### PR DESCRIPTION
Changed the NTP server to `pool.ntp.org`as described in this [comment](https://github.com/Magisk-Modules-Alt-Repo/supl-replacer/issues/3#issuecomment-1892796390).
Added the option to patch the `/system/etc/gps_debug.conf` to devices that have it instead of the standart `gps.conf`; May fix problems described on this [issue](https://github.com/Magisk-Modules-Alt-Repo/supl-replacer/issues/2) (worked for me).
Also added the default port to `supl.grapheneos.org` (7275) to `post-fs-data.sh`, because some devices don't have it as the default port.

Cheers!